### PR TITLE
Fix lodash issue and pin dependencies

### DIFF
--- a/elb2loggly.js
+++ b/elb2loggly.js
@@ -224,8 +224,8 @@ exports.handler = function(event, context) {
 				    else {
 				    
 				    //Get an array of bucket tags
-					var s3tag = _.zipObject(_.pluck(data['TagSet'], 'Key'),
-									_.pluck(data['TagSet'], 'Value'));
+					var s3tag = _.zipObject(_.map(data['TagSet'], 'Key'),
+									_.map(data['TagSet'], 'Value'));
 
 					//If the 'token' tag is set we use that
 					if (s3tag[BUCKET_LOGGLY_TOKEN_NAME]) {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,13 @@
   "license": "Proprietary",
   "devDependencies": {},
   "engine": "node >= 0.10",
-  "dependencies": 
-  { "async"         : "latest"
-  , "csv-streamify" : "latest"
-  , "JSONStream"    : "latest"
-  , "lodash"        : "latest"
-  , "request"       : "latest"
+  "dependencies":
+  { "async"         : "^1.5.2"
+  , "csv-streamify" : "^3.0.3"
+  , "JSONStream"    : "^1.0.7"
+  , "lodash"        : "^4.5.1"
+  , "request"       : "^2.69.0"
   },
   "scripts": {
   }
 }
-


### PR DESCRIPTION
The PR fixes two issues:
- [lodash](https://lodash.com) removed `_.pluck` in favor of `_.map` in v4.0
- Latest versions of the dependencies were used, hence the issue above

`_.pluck` is replaced with `_.map` and dependencies are pinned to their current latest versions. Patch version releases will be installed by `npm`, but major and minor releases will need to be tested and bumped manually (although probably not necessary).

I'm not sure about the line `"license": "Proprietary"` in `package.json`. Maybe an open source license would better fit the project.

Thanks for putting the project together @cboscolo!
