### PR TITLE
Add support for S3 object prefix tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Using S3 Management Console click the bucket that contains your ELB logs.
     * **Key:** loggly-tag
     * **Value:** *aws-elb* (Or what ever you want.)
   3. And this tag (will add the ELB log prefix as additional tag):
-    * **Key:** prefix-tag
-    * **Value:** *true* (Or what ever you want.)
+    * **Key:** add-log-prefix-tag
+    * **Value:** *true* (All other values will disable the extra tag)
 
 ### Private URL parameters
 If your ELB logs contain private URL parameters such as authentication tokens, e.g.:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For all of the AWS setup, I used the AWS console following [this example](http:/
     * Upload lambda function (zip file you made above.)
     * **Handler*:** *elb2loggly.handler*
     * **Role*:** In the drop down click "S3 execution role". (This will open a new window to create the role.) Before clicking the "Allow" button to save this new Role, click the "> View Policy Document", then edit and change the Aciton from "s3:GetObject" to "s3:Get*"
-    * I left the memory at 128MB.  In my testing with ELBs set upload every 5 minutes this worked for me.  You may need to bump this up if your ELB logs are larger.  
+    * I left the memory at 128MB.  In my testing with ELBs set upload every 5 minutes this worked for me.  You may need to bump this up if your ELB logs are larger.
     * Same advice for Timer, I set it to 10 seconds.
 2. Configure Event Source to call elb2loggly when logs added to S3 bucket.
   1. https://console.aws.amazon.com/lambda/home
@@ -47,21 +47,24 @@ Using S3 Management Console click the bucket that contains your ELB logs.
   1. Under Properties -> Tags add the following tag:
     * **Key:** loggly-customer-token
     * **Value:** *your-loggly-customer-token*
-  2. And optionally this tag (will tag log entries in loggly):
+  2. Optionally this tag (will tag log entries in loggly):
     * **Key:** loggly-tag
     * **Value:** *aws-elb* (Or what ever you want.)
+  3. And this tag (will add the ELB log prefix as additional tag):
+    * **Key:** prefix-tag
+    * **Value:** *true* (Or what ever you want.)
 
 ### Private URL parameters
 If your ELB logs contain private URL parameters such as authentication tokens, e.g.:
-   
+
   *https://api.loggly.com/getinfo?infoid=45&authToken=kjhs87234kjhsdf897234kjhs01ka9234*
-   
+
 you can obscure this information when sending the data to loggly. Add an additional tag to your S3 bucket:
   * **Key:** elb2loggly-private-url-params
   * **Value:** *authToken/10*
 
 This will obscure all *authToken* parameters with an obscure length of *10*, e.g.:
-  
+
   *https://api.loggly.com/getinfo?infoid=45&authToken=kjhs87234k...*
 
 Notes:

--- a/elb2loggly.js
+++ b/elb2loggly.js
@@ -18,7 +18,7 @@ var JSONStream = require('JSONStream');
 var LOGGLY_URL_BASE = 'https://logs-01.loggly.com/bulk/';
 var BUCKET_LOGGLY_TOKEN_NAME = 'loggly-customer-token';
 var BUCKET_LOGGLY_TAG_NAME = 'loggly-tag';
-var OBJECT_PREFIX_TAG_ENABLED = 'prefix-tag';
+var OBJECT_PREFIX_TAG_ENABLED = 'add-log-prefix-tag';
 var BUCKET_LOGGLY_PRIVATE_URL_PARAMS_NAME = 'elb2loggly-private-url-params';
 
 var LOGGLY_URL = null;
@@ -247,7 +247,7 @@ exports.handler = function(event, context) {
                 tags.push(s3tag[BUCKET_LOGGLY_TAG_NAME])
               }
                 // If the 'object prefix' tag is set we use that
-              if (s3tag[OBJECT_PREFIX_TAG_ENABLED]) {
+              if (s3tag[OBJECT_PREFIX_TAG_ENABLED] && s3tag[OBJECT_PREFIX_TAG_ENABLED] == 'true') {
                 tags.push(key.split('/')[0]);
               }
                 // Generate URL with tags

--- a/elb2loggly.js
+++ b/elb2loggly.js
@@ -18,6 +18,7 @@ var JSONStream = require('JSONStream');
 var LOGGLY_URL_BASE = 'https://logs-01.loggly.com/bulk/';
 var BUCKET_LOGGLY_TOKEN_NAME = 'loggly-customer-token';
 var BUCKET_LOGGLY_TAG_NAME = 'loggly-tag';
+var OBJECT_PREFIX_TAG_ENABLED = 'prefix-tag';
 var BUCKET_LOGGLY_PRIVATE_URL_PARAMS_NAME = 'elb2loggly-private-url-params';
 
 var LOGGLY_URL = null;
@@ -228,6 +229,7 @@ exports.handler = function(event, context) {
         };
 
         s3.getBucketTagging(params, function(err, data) {
+          var tags = [];
           if (err) {
             next(err);
             console.log(err, err.stack);
@@ -242,7 +244,15 @@ exports.handler = function(event, context) {
 
                 // If the 'loggly tag' tag is set we use that
               if (s3tag[BUCKET_LOGGLY_TAG_NAME]) {
-                LOGGLY_URL += '/tag/' + s3tag[BUCKET_LOGGLY_TAG_NAME];
+                tags.push(s3tag[BUCKET_LOGGLY_TAG_NAME])
+              }
+                // If the 'object prefix' tag is set we use that
+              if (s3tag[OBJECT_PREFIX_TAG_ENABLED]) {
+                tags.push(key.split('/')[0]);
+              }
+                // Generate URL with tags
+              if (tags.length) {
+                LOGGLY_URL += '/tag/' + tags.join(',');
               }
             } else {
               LOGGLY_URL = DEFAULT_LOGGLY_URL;


### PR DESCRIPTION
We are using one shared bucket for a bunch of ELBs but using a log prefix with the ELB name to separate the log events. To attach ELB logs to a source group in Loggly, we need an additional tag in our logs with the ELB name.

This pull requests adds the functionality that if an additional tag _prefix-tag_ (value does not matter) is added to the S3 bucket, the Lambda function will extract the first prefix of the log file path and add it as an additional Loggly tag. So for example if the full S3 path is `my-awesome-elb/AWSLogs/1111/elasticloadbalancing/us-west-2/2016/05/19/1111_elasticloadbalancing_us-west-2_my-awesome-elb`, it will add the tag **my-awesome-elb** to all log events.

I do not have too much experience with Lambda code, so please let me know if I am missing something to make this merge-able.
